### PR TITLE
适配最新的openai的API版本

### DIFF
--- a/content/必修一-/2. 提示原则 Guidelines.ipynb
+++ b/content/必修一-/2. 提示原则 Guidelines.ipynb
@@ -63,17 +63,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openai\n",
+    "import os\n",
+    "from openai import OpenAI\n",
+    "# from dotenv import load_dotenv\n",
     "# 导入第三方库\n",
-    "\n",
-    "openai.api_key  = \"sk-...\"\n",
-    "# 设置 API_KEY, 请替换成您自己的 API_KEY\n",
-    "\n",
-    "# 以下为基于环境变量的配置方法示例，这样更加安全。仅供参考，后续将不再涉及。\n",
-    "# import openai\n",
-    "# import os\n",
-    "# OPENAI_API_KEY = os.environ.get(\"OPENAI_API_KEY\")\n",
-    "# openai.api_key = OPENAI_API_KEY\n"
+    "# 以下为基于环境变量的配置方法示例，这样更加安全。仅供参考，后续将不再涉及。[.env文件中配置API_KEY: API_KEY=sk-...](.env文件必须放在根目录下)\n",
+    "# load_dotenv()\n",
+    "# api_key = os.environ.get('API_KEY')\n",
+    "api_key = \"sk-...\" # 请替换成您自己的 API_KEY，仅供参考\n",
+    "client = OpenAI(api_key=api_key)\n"
    ]
   },
   {
@@ -97,13 +95,13 @@
     "    model: 调用的模型，默认为 gpt-3.5-turbo(ChatGPT)，有内测资格的用户可以选择 gpt-4\n",
     "    '''\n",
     "    messages = [{\"role\": \"user\", \"content\": prompt}]\n",
-    "    response = openai.ChatCompletion.create(\n",
+    "    response = client.chat.completions.create(\n",
     "        model=model,\n",
     "        messages=messages,\n",
     "        temperature=0, # 模型输出的温度系数，控制输出的随机程度\n",
     "    )\n",
     "    # 调用 OpenAI 的 ChatCompletion 接口\n",
-    "    return response.choices[0].message[\"content\"]\n"
+    "    return response.choices[0].message.content\n"
    ]
   },
   {


### PR DESCRIPTION
修复了哪些问题：
1. 用openai推荐方法设置API_KEY，同时为下文函数作准备
2. openai版本更新后（>=1.0.0）不再支持openai.ChatCompletion，改为client.chat.completions。
3. 函数中返回值（response.choices[0].message["content"]）测试后报错：TypeError: 'ChatCompletionMessage' object is not subscriptable。更新为response.choices[0].message.content。